### PR TITLE
Task 11/14: Split randomGeneratingSets and add Minimal strategy

### DIFF
--- a/RandomMonomialIdeals.m2
+++ b/RandomMonomialIdeals.m2
@@ -126,7 +126,7 @@ randomMinimalGeneratingSet = (n,D,p) -> (
  x:=symbol x;
  R:=QQ[x_1..x_n];
  B:={};
- currentRing=R;
+ currentRing:=R;
  apply(D, d-> (
   chosen:=select(flatten entries basis(d+1,currentRing), m->random(0.0,1.0)<=p_d);
   B=flatten append(B, chosen/(i->sub(i, R)));

--- a/RandomMonomialIdeals.m2
+++ b/RandomMonomialIdeals.m2
@@ -123,7 +123,19 @@ randomGeneratingSet (ZZ,ZZ,List) := List => o -> (n,D,p) -> (
 --**********************************--
 
 
-randomMinimalGeneratingSets = (n,D,p) -> null;
+randomMinimalGeneratingSets(ZZ,ZZ,List) = (n,D,p) -> (
+ x:=symbol x;
+ R:=QQ[x_1..x_n];
+ B:={};
+ currentRing=R;
+ apply(D, d-> (
+  chosen:=select(flatten entries basis(d+1,currentRing), m->random(0.0,1.0)<=p_d);
+  B=flatten append(B, chosen/(i->sub(i, R)));
+  currentRing = currentRing/promote(ideal(chosen),currentRing)
+  )
+);
+ return(B)
+ )
 
 --******************************************--
 -- DOCUMENTATION     	       	    	    -- 
@@ -251,7 +263,44 @@ TEST ///
     assert(1==min(apply((randomGeneratingSets(n,D,1.0,1))#0,m->first degree m)))
     assert(1==min(apply((randomGeneratingSets(n,D,toList(D:1.0),1))#0,m->first degree m)))
 ///
-
+TEST ///
+-- Check no terms are chosen for a probability of 0
+n=4;
+assert ({}=randomMinGeneratingSet(n,5,0.0))
+assert ({}=randomMinGeneratingSet(n,4,n:0.0))
+///
+TEST ///
+-- Check all possible monomials of degree d are outputted with probability 1.0
+n=4;
+D=5;
+assert (# flatten entries basis (1, QQ[x_1..x_n])==#randomMinGeneratingSet(n,D,1.0))
+assert (# flatten entries basis (2, QQ[x_1..x_n])==#randomMinGeneratingSet(n,D,(0.0,1.0,1.0,1.0,1.0))
+assert (# flatten entries basis (3, QQ[x_1..x_n])==#randomMinGeneratingSet(n,D,(0.0,0.0,1.0,1.0,1.0))
+assert (# flatten entries basis (4, QQ[x_1..x_n])==#randomMinGeneratingSet(n,D,(0.0,0.0,0.0,1.0,1.0))
+assert (# flatten entries basis (5, QQ[x_1..x_n])==#randomMinGeneratingSet(n,D,(0.0,0.0,0.0,0.0,1.0))
+///
+TEST ///
+-- Check all monomials of degree d are generated with probability 1.0
+L=randomMinGeneratingSet(3,3,1.0);
+R=ring(L#0)
+assert(set L===set {R_0, R_1, R_2})
+L=randomMinGeneratingSet(3,3,(0.0,1.0,1.0))
+assert(set L===set {R_0^2,R_0*R_1,R_1^2,R_0*R_2,R_1*R_2,R_2^2})
+L=randomMinGeneratingSet(3,3,(0.0,0.0,1.0))
+assert(set L===set {R_0^3,R_0^2*R_1,R_0^2*R_2,R_0*R_1*R_2,R_1^3,R_0*R_1^2,R_1^2*R_2,R_0*R_2^2,R_1*R_2^2,R_2^3})
+///
+TEST ///
+-- Check max degree of monomial less than or equal to D
+n=10;
+D=5;
+assert(D==max(apply((randomGeneratingSets(n,D,(0.0,0.0,0.0,0.0,1.0))#0,m->first degree m)))
+///
+TEST ///
+-- Check min degree of monomial greater than or equal to 1
+n=10;
+D=5;
+assert(D==min(apply((randomGeneratingSets(n,D,1.0)#0,m->first degree m)))
+///
 end
 
 You can write anything you want down here.  I like to keep examples

--- a/RandomMonomialIdeals.m2
+++ b/RandomMonomialIdeals.m2
@@ -111,9 +111,9 @@ randomGeneratingSet (ZZ,ZZ,List) := List => o -> (n,D,p) -> (
     if #p != D then error "p expected to be a list of length D";
     if any(p,q-> q<0.0 or 1.0<q) then error "p expected to be a list of real numbers between 0.0 and 1.0";
     if o.Strategy === Minimal then
-        return null;--randomMinimalGeneratingSets(n,D,toList(D:p),N)
     x := symbol x;
     R := QQ[x_1..x_n];
+        return randomMinimalGeneratingSets(n,D,toList(D:p));
     B := flatten apply(toList(1..D),d-> select(flatten entries basis(d,R),m-> random(0.0,1.0)<=p_(d-1)));
     if B==={} then {0_R} else B
 )
@@ -123,6 +123,7 @@ randomGeneratingSet (ZZ,ZZ,List) := List => o -> (n,D,p) -> (
 --**********************************--
 
 
+randomMinimalGeneratingSets = (n,D,p) -> null;
 
 --******************************************--
 -- DOCUMENTATION     	       	    	    -- 

--- a/RandomMonomialIdeals.m2
+++ b/RandomMonomialIdeals.m2
@@ -113,7 +113,7 @@ randomGeneratingSet (ZZ,ZZ,List) := List => o -> (n,D,p) -> (
     if o.Strategy === Minimal then
     x := symbol x;
     R := QQ[x_1..x_n];
-        return randomMinimalGeneratingSets(n,D,toList(D:p));
+        return randomMinimalGeneratingSet(n,D,toList(D:p));
     B := flatten apply(toList(1..D),d-> select(flatten entries basis(d,R),m-> random(0.0,1.0)<=p_(d-1)));
     if B==={} then {0_R} else B
 )
@@ -122,8 +122,8 @@ randomGeneratingSet (ZZ,ZZ,List) := List => o -> (n,D,p) -> (
 --  Internal methods	    	    --
 --**********************************--
 
-
-randomMinimalGeneratingSets(ZZ,ZZ,List) = (n,D,p) -> (
+randomMinimalGeneratingSet = method();
+randomMinimalGeneratingSet(ZZ,ZZ,List) = (n,D,p) -> (
  x:=symbol x;
  R:=QQ[x_1..x_n];
  B:={};

--- a/RandomMonomialIdeals.m2
+++ b/RandomMonomialIdeals.m2
@@ -122,8 +122,7 @@ randomGeneratingSet (ZZ,ZZ,List) := List => o -> (n,D,p) -> (
 --  Internal methods	    	    --
 --**********************************--
 
-randomMinimalGeneratingSet = method();
-randomMinimalGeneratingSet(ZZ,ZZ,List) = (n,D,p) -> (
+randomMinimalGeneratingSet = (n,D,p) -> (
  x:=symbol x;
  R:=QQ[x_1..x_n];
  B:={};

--- a/RandomMonomialIdeals.m2
+++ b/RandomMonomialIdeals.m2
@@ -111,9 +111,9 @@ randomGeneratingSet (ZZ,ZZ,List) := List => o -> (n,D,p) -> (
     if #p != D then error "p expected to be a list of length D";
     if any(p,q-> q<0.0 or 1.0<q) then error "p expected to be a list of real numbers between 0.0 and 1.0";
     if o.Strategy === Minimal then
+        return randomMinimalGeneratingSet(n,D,p);
     x := symbol x;
     R := QQ[x_1..x_n];
-        return randomMinimalGeneratingSet(n,D,toList(D:p));
     B := flatten apply(toList(1..D),d-> select(flatten entries basis(d,R),m-> random(0.0,1.0)<=p_(d-1)));
     if B==={} then {0_R} else B
 )
@@ -123,18 +123,18 @@ randomGeneratingSet (ZZ,ZZ,List) := List => o -> (n,D,p) -> (
 --**********************************--
 
 randomMinimalGeneratingSet = (n,D,p) -> (
- x:=symbol x;
- R:=QQ[x_1..x_n];
- B:={};
+ x := symbol x;
+ R := QQ[x_1..x_n];
+ B := {};
  currentRing:=R;
- apply(D, d-> (
-  chosen:=select(flatten entries basis(d+1,currentRing), m->random(0.0,1.0)<=p_d);
-  B=flatten append(B, chosen/(i->sub(i, R)));
-  currentRing = currentRing/promote(ideal(chosen),currentRing)
+ apply(D, d->(
+   chosen:=select(flatten entries basis(d+1,currentRing), m->random(0.0,1.0)<=p_d);
+   B = flatten append(B, chosen/(i->sub(i, R)));
+   currentRing = currentRing/promote(ideal(chosen),currentRing)
   )
-);
+ );
  return(B)
- )
+)
 
 --******************************************--
 -- DOCUMENTATION     	       	    	    -- 

--- a/RandomMonomialIdeals.m2
+++ b/RandomMonomialIdeals.m2
@@ -69,20 +69,9 @@ export {
 
 randomGeneratingSets = method(TypicalValue => List)
 randomGeneratingSets (ZZ,ZZ,RR,ZZ) := List =>  (n,D,p,N) -> (
-    x :=symbol x;
-    R := QQ[x_1..x_n];
-
-    allMonomials := flatten flatten apply(toList(1..D),d->entries basis(d,R));
-    -- this generates a list of all possible monomials of degree <= D in n variables
-    -- go through list allMonomials, and for each monomial m in the list, select a number in Unif(0,1);
-    -- if that number <= p, then include the monomial m in a generating set B
-    -- since iid~Unif(0,1), this is same as keeping each possible monomial w/ probability p.
-    -- we need a sample of size N of sets of monomials like these, so we repeat this process N times:
-    B := apply(N,i-> select(allMonomials, m-> random(0.0,1.0)<=p) );
-    -- we need 0 ideals stored in the appropriate ring; hence do this: 
-    apply(#B,i-> if B_i==={} then B=replace(i,{0_R},B));
-    return(B)
+    randomGeneratingSets(n,D,toList(D:p),N)
 )
+
 randomGeneratingSets (ZZ,ZZ,ZZ,ZZ) := List =>  (n,D,M,N) -> (
     x :=symbol x;
     R := QQ[x_1..x_n];
@@ -95,11 +84,10 @@ randomGeneratingSets (ZZ,ZZ,ZZ,ZZ) := List =>  (n,D,M,N) -> (
 )
 
 randomGeneratingSets (ZZ,ZZ,List,ZZ) := List =>  (n,D,p,N) -> (
-    x :=symbol x;
+    x := symbol x;
     R := QQ[x_1..x_n];
     B := apply(N,i-> flatten apply(toList(1..D),d-> select(flatten entries basis(d,R),m-> random(0.0,1.0)<=p_(d-1))));
-    apply(#B,i-> if B_i==={} then B=replace(i,{0_R},B));
-    return(B)
+    apply(B,b-> if b==={} then {0_R} else b)
 )
 
 --**********************************--


### PR DESCRIPTION
@dkosmas @rosborn

Added errors and warning messages for invalid or suspect inputs.

Options to select the coefficients and the variable name for the generated polynomial ring were added.

Code for generating the minimal generating sets was added.

Tests for the Minimal strategy were created.

Tests for randomGeneratingSets were split from tests for randomGeneratingSet.

Issues:
When documenting `randomGeneratingSet`, should it be a short description with links to `randomGeneratingSets`? The other option would be to adjust our current documentation to document `randomGeneratingSet` and have `randomGeneratingSets` state that it runs it `N` times. If `randomGeneratingSets` is advertised as the most common use case, then it would make sense to keep the main documentation and examples in its help page. Do you have a strong preference for one or the other? @Sondzus @sdgpfo 