### PR TITLE
task30 - part 2 - unifying one more output type

### DIFF
--- a/RandomMonomialIdeals.m2
+++ b/RandomMonomialIdeals.m2
@@ -492,7 +492,7 @@ doc ///
   N: ZZ
     number of sets generated
  Outputs
-  B: List
+  : List
    random generating sets of monomials
  Description
   Text


### PR DESCRIPTION
This is just 1 small change to match all other methods (no need for naming the output, there’s only
one). Last to-do item for TASK30-consistency. 

- [x] check that it installs
- [x] merge. 